### PR TITLE
Add extension settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ PokemonGPT is a Chrome extension that acts as an AI battle assistant for [Pokém
 1. Clone this repository and open the `chrome://extensions` page in Chrome.
 2. Enable **Developer mode** and load the extension directory as an unpacked extension.
 3. Open a Pokémon Showdown battle and the assistant will suggest and select moves automatically.
+4. Use the extension's **Options** page to enable/disable the assistant and adjust the LLM temperature.
 
 ## Development Guide
 
@@ -43,9 +44,9 @@ The following tasks outline the work needed to complete the extension:
 4. **Automate UI interaction.** *(completed)*
    - The extension now programmatically clicks the recommended move in the Showdown interface.
 
-5. **Add configuration and settings.**
-   - Allow users to enable/disable the assistant.
-   - Provide controls to adjust LLM parameters if needed.
+5. **Add configuration and settings.** *(completed)*
+   - Added an options page where users can enable/disable the assistant.
+   - Provided a control to adjust the LLM temperature parameter.
 
 6. **Testing and refinement.**
    - Test the assistant in various battle scenarios.

--- a/background.js
+++ b/background.js
@@ -6,15 +6,31 @@ console.log('PokemonGPT background service worker initialized');
 // Local API endpoint for move recommendations
 const API_URL = 'http://localhost:5000/move';
 
+// Current user settings
+let settings = { enabled: true, temperature: 0.7 };
+chrome.storage.local.get(settings, items => {
+  settings = items;
+});
+
+chrome.storage.onChanged.addListener(changes => {
+  if (changes.enabled) settings.enabled = changes.enabled.newValue;
+  if (changes.temperature) settings.temperature = changes.temperature.newValue;
+});
+
 // Listen for updates from the content script with parsed battle state data.
 chrome.runtime.onMessage.addListener((message, sender) => {
   if (message.type === 'battle_state') {
     console.log('Received battle state', message.state);
 
+    if (!settings.enabled) {
+      console.log('PokemonGPT disabled; ignoring battle state');
+      return;
+    }
+
     fetch(API_URL, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(message.state)
+      body: JSON.stringify({ ...message.state, temperature: settings.temperature })
     })
       .then(res => res.json())
       .then(data => {

--- a/manifest.json
+++ b/manifest.json
@@ -19,5 +19,6 @@
   ],
   "action": {
     "default_title": "PokemonGPT"
-  }
+  },
+  "options_page": "options.html"
 }

--- a/options.html
+++ b/options.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>PokemonGPT Settings</title>
+  <style>
+    body { font-family: Arial, sans-serif; padding: 1em; }
+    label { display: block; margin-bottom: 0.5em; }
+  </style>
+</head>
+<body>
+  <h1>PokemonGPT Settings</h1>
+  <label>
+    <input type="checkbox" id="enabled">
+    Enable assistant
+  </label>
+  <label>
+    LLM Temperature:
+    <input type="number" id="temperature" step="0.1" min="0" max="1">
+  </label>
+  <script src="options.js"></script>
+</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,19 @@
+// Handles saving and loading of PokemonGPT settings.
+document.addEventListener('DOMContentLoaded', () => {
+  const enabledEl = document.getElementById('enabled');
+  const temperatureEl = document.getElementById('temperature');
+
+  chrome.storage.local.get({ enabled: true, temperature: 0.7 }, items => {
+    enabledEl.checked = items.enabled;
+    temperatureEl.value = items.temperature;
+  });
+
+  enabledEl.addEventListener('change', () => {
+    chrome.storage.local.set({ enabled: enabledEl.checked });
+  });
+
+  temperatureEl.addEventListener('change', () => {
+    const value = parseFloat(temperatureEl.value);
+    chrome.storage.local.set({ temperature: value });
+  });
+});


### PR DESCRIPTION
## Summary
- add options page and JS to manage settings
- handle settings in background.js
- mention options usage in README
- mark configuration task as complete in task list

## Testing
- `npm run lint` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685c7b6578648327a1bea807a5a0f2e7