### PR TITLE
Fix temperature parsing preserving 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ The following tasks outline the work needed to complete the extension:
    - Added an options page to provide an OpenAI API key, model name and temperature.
    - Users can enable/disable and tweak assistant parameters.
 
-6. **Testing and refinement.**
+ 6. **Testing and refinement.**
    - Test the assistant in various battle scenarios.
    - Iterate on the LLM prompt and logic for better decision making.
+   - Fix options page to handle a temperature value of 0.
 
 Contributions should update this task list as work progresses.

--- a/options.js
+++ b/options.js
@@ -11,7 +11,8 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('save').addEventListener('click', () => {
     const apiKey = document.getElementById('apiKey').value.trim();
     const model = document.getElementById('model').value.trim() || 'gpt-4o';
-    const temperature = parseFloat(document.getElementById('temperature').value) || 1;
+    let temperature = parseFloat(document.getElementById('temperature').value);
+    if (isNaN(temperature)) temperature = 1;
     chrome.storage.sync.set({ apiKey, model, temperature }, () => {
       alert('Settings saved');
     });


### PR DESCRIPTION
## Summary
- fix temperature parsing in options page to handle 0 value
- note the fix in the task list

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685c9ba614848327a3b44efa6b606a4f