### PR TITLE
Add quick access to settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,4 +68,7 @@ The following tasks outline the work needed to complete the extension:
    - Track HP percentages and status for active Pokémon each turn.
    - Send this richer state information to the language model.
 
+9. **Open settings from extension icon.** *(completed)*
+   - Clicking the PokemonGPT icon now opens the options page for quick access.
+
 Contributions should update this task list as work progresses.

--- a/background.js
+++ b/background.js
@@ -3,6 +3,11 @@
 
 console.log('PokemonGPT background service worker initialized');
 
+// Open the settings page when the extension icon is clicked
+chrome.action.onClicked.addListener(() => {
+  chrome.runtime.openOptionsPage();
+});
+
 const DEFAULT_SETTINGS = {
   apiKey: '',
   model: 'gpt-4o',


### PR DESCRIPTION
## Summary
- allow opening options page when clicking the extension icon
- document new feature in the task list

## Testing
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685caf4994ec8327b88b5c6bba170003