### PR TITLE
Add dropdown for OpenAI models

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,4 +79,7 @@ The following tasks outline the work needed to complete the extension:
     - Sidebar messages are styled like a simple chat UI.
     - Users see a message when the OpenAI API key is missing or invalid.
 
+12. **Add model dropdown for updated OpenAI models.** *(completed)*
+    - Options page now provides a select list of model names instead of a text field.
+
 Contributions should update this task list as work progresses.

--- a/options.html
+++ b/options.html
@@ -13,7 +13,18 @@
   <br />
   <label>
     Model:
-    <input type="text" id="model" placeholder="gpt-4o" />
+    <select id="model">
+      <option value="gpt-4o">gpt-4o</option>
+      <option value="gpt-4o-latest">gpt-4o-latest</option>
+      <option value="gpt-4-turbo">gpt-4-turbo</option>
+      <option value="gpt-4">gpt-4</option>
+      <option value="gpt-4-1106-preview">gpt-4-1106-preview</option>
+      <option value="gpt-4-0125-preview">gpt-4-0125-preview</option>
+      <option value="gpt-3.5-turbo">gpt-3.5-turbo</option>
+      <option value="gpt-3.5-turbo-1106">gpt-3.5-turbo-1106</option>
+      <option value="gpt-3.5-turbo-0125">gpt-3.5-turbo-0125</option>
+      <option value="gpt-3.5-turbo-instruct">gpt-3.5-turbo-instruct</option>
+    </select>
   </label>
   <br />
   <label>


### PR DESCRIPTION
## Summary
- allow choosing the LLM model from a dropdown
- document model dropdown in the task list

## Testing
- `npm run lint` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685f7a0d0d788327bdbeaaf2ad33772b