### PR TITLE
Adjust layout when sidebar visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,4 +94,7 @@ The following tasks outline the work needed to complete the extension:
 15. **Show assistant status in the sidebar.** *(completed)*
     - A new status line indicates when the AI is thinking, executing a move, or waiting for the next turn.
 
+16. **Resize battle screen when sidebar is open.** *(completed)*
+    - The main page now shifts left so the sidebar no longer covers information.
+
 Contributions should update this task list as work progresses.

--- a/content.js
+++ b/content.js
@@ -3,6 +3,8 @@
 
 console.log('PokemonGPT content script loaded');
 
+const SIDEBAR_WIDTH = 300;
+
 let enabled = true;
 let sidebar;
 let logContainer;
@@ -13,7 +15,7 @@ function createSidebar() {
   sidebar = document.createElement('div');
   sidebar.id = 'pokemon-gpt-sidebar';
   sidebar.style.cssText =
-    'position:fixed;top:0;right:0;width:300px;height:100%;' +
+    `position:fixed;top:0;right:0;width:${SIDEBAR_WIDTH}px;height:100%;` +
     'background:#f7f7f7;z-index:10000;border-left:1px solid #ccc;' +
     'display:flex;flex-direction:column;font-family:sans-serif;font-size:12px;';
 
@@ -62,10 +64,12 @@ function createSidebar() {
 function showSidebar() {
   if (!sidebar) createSidebar();
   sidebar.style.display = 'block';
+  document.body.style.marginRight = `${SIDEBAR_WIDTH}px`;
 }
 
 function hideSidebar() {
   if (sidebar) sidebar.style.display = 'none';
+  document.body.style.marginRight = '';
 }
 
 function setStatus(text) {


### PR DESCRIPTION
## Summary
- shift page content left by sidebar width when the sidebar opens
- reset page width when the sidebar hides
- document new completed task about resizing the battle screen

## Testing
- `npm run lint` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6864a35864a48327887bb79e2a63ab0f