### PR TITLE
Fix late battle detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,4 +97,7 @@ The following tasks outline the work needed to complete the extension:
 16. **Resize battle screen when sidebar is open.** *(completed)*
     - The main page now shifts left so the sidebar no longer covers information.
 
+17. **Handle late battle start detection.** *(completed)*
+    - The content script now watches for the battle element to appear even after page load.
+
 Contributions should update this task list as work progresses.

--- a/content.js
+++ b/content.js
@@ -115,9 +115,11 @@ chrome.storage.onChanged.addListener((changes, area) => {
     enabled = changes.enabled.newValue;
     if (enabled) {
       showSidebar();
+      setupObserver();
       reportBattleState();
     } else {
       hideSidebar();
+      if (observer) observer.disconnect();
     }
   }
 });
@@ -275,10 +277,20 @@ chrome.runtime.onMessage.addListener(message => {
 // Observe changes within the battle container so we can update the state when
 // the UI changes (e.g., after selecting a move or when a new Pokémon switches in).
 function setupObserver() {
-  const battleContainer = document.getElementById('battle');
-  if (battleContainer) {
+  function attach() {
+    const battleContainer = document.getElementById('battle');
+    if (!battleContainer) return false;
+    if (observer) observer.disconnect();
     observer = new MutationObserver(() => reportBattleState());
     observer.observe(battleContainer, { childList: true, subtree: true });
     if (enabled) reportBattleState();
+    return true;
+  }
+
+  if (!attach()) {
+    const tempObserver = new MutationObserver(() => {
+      if (attach()) tempObserver.disconnect();
+    });
+    tempObserver.observe(document.body, { childList: true, subtree: true });
   }
 }


### PR DESCRIPTION
## Summary
- detect battles that begin after the page loads
- reconnect the observer when the extension is re-enabled
- document the new completed task

## Testing
- `npm run lint` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6864a758accc83278d7e2187d3e83f88